### PR TITLE
[톰캣 구현하기 - 3, 4단계] 필립(양재필) 미션 제출합니다.

### DIFF
--- a/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
@@ -1,0 +1,62 @@
+package nextstep.jwp.controller;
+
+import nextstep.jwp.db.InMemoryUserRepository;
+import nextstep.jwp.model.User;
+import org.apache.catalina.controller.AbstrcatController;
+import org.apache.catalina.session.Session;
+import org.apache.catalina.session.SessionManager;
+import org.apache.coyote.http11.request.HttpRequest;
+import org.apache.coyote.http11.response.HttpResponse;
+
+import static org.apache.catalina.session.Session.JSESSIONID_COOKIE_NAME;
+
+public class LoginController extends AbstrcatController {
+
+    private static final String MAPPED_URL = "/login";
+    private static final String LOGIN_USER_REDIRECT_PAGE = "index.html";
+    private static final String LOGIN_PAGE = "login.html";
+    private static final String UNAUTHORIZED_PAGE = "/401.html";
+    private static final String ACCOUNT_KEY = "account";
+    private static final String PASSWORD_KEY = "password";
+
+    @Override
+    protected void doGet(final HttpRequest request, final HttpResponse response) throws Exception {
+        final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
+
+        if (session != null && session.getUser() instanceof User) {
+            response.redirectTo(LOGIN_USER_REDIRECT_PAGE);
+            return;
+        }
+        response.hostingPage(LOGIN_PAGE);
+    }
+
+    @Override
+    protected void doPost(final HttpRequest request, final HttpResponse response) throws Exception {
+        final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
+
+        if (processLogin(request)) {
+            final User user = InMemoryUserRepository.findByAccount(request.getBody(ACCOUNT_KEY)).get();
+            session.setUser(user);
+            response.redirectTo(LOGIN_USER_REDIRECT_PAGE);
+            return;
+        }
+        response.redirectTo(UNAUTHORIZED_PAGE);
+    }
+
+    private boolean processLogin(final HttpRequest request) {
+        if (!request.containsBody(ACCOUNT_KEY) || !request.containsBody(PASSWORD_KEY)) {
+            return false;
+        }
+        final String account = request.getBody(ACCOUNT_KEY);
+        final String password = request.getBody(PASSWORD_KEY);
+
+        return InMemoryUserRepository.findByAccount(account)
+                .map(user -> user.checkPassword(password))
+                .orElse(false);
+    }
+
+    @Override
+    public boolean isMappedController(HttpRequest request) {
+        return MAPPED_URL.equals(request.getPath());
+    }
+}

--- a/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
@@ -37,7 +37,7 @@ public class LoginController extends AbstrcatController {
 
     @Override
     protected void doPost(final HttpRequest request, final HttpResponse response) throws Exception {
-        final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
+        final Session session = getSession(request, response);
 
         if (processLogin(request)) {
             final User user = InMemoryUserRepository.findByAccount(request.getBody(ACCOUNT_KEY)).get();

--- a/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
@@ -5,6 +5,7 @@ import nextstep.jwp.model.User;
 import org.apache.catalina.controller.AbstrcatController;
 import org.apache.catalina.session.Session;
 import org.apache.catalina.session.SessionManager;
+import org.apache.coyote.http11.exception.MissingRequestBody;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.response.HttpResponse;
 
@@ -49,7 +50,7 @@ public class LoginController extends AbstrcatController {
 
     private boolean processLogin(final HttpRequest request) {
         if (!request.containsBody(ACCOUNT_KEY) || !request.containsBody(PASSWORD_KEY)) {
-            return false;
+            throw new MissingRequestBody();
         }
         final String account = request.getBody(ACCOUNT_KEY);
         final String password = request.getBody(PASSWORD_KEY);

--- a/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/LoginController.java
@@ -19,6 +19,10 @@ public class LoginController extends AbstrcatController {
     private static final String ACCOUNT_KEY = "account";
     private static final String PASSWORD_KEY = "password";
 
+    public LoginController() {
+        super(MAPPED_URL);
+    }
+
     @Override
     protected void doGet(final HttpRequest request, final HttpResponse response) throws Exception {
         final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
@@ -53,10 +57,5 @@ public class LoginController extends AbstrcatController {
         return InMemoryUserRepository.findByAccount(account)
                 .map(user -> user.checkPassword(password))
                 .orElse(false);
-    }
-
-    @Override
-    public boolean isMappedController(HttpRequest request) {
-        return MAPPED_URL.equals(request.getPath());
     }
 }

--- a/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
@@ -1,0 +1,62 @@
+package nextstep.jwp.controller;
+
+import nextstep.jwp.db.InMemoryUserRepository;
+import nextstep.jwp.model.User;
+import org.apache.catalina.controller.AbstrcatController;
+import org.apache.catalina.session.Session;
+import org.apache.catalina.session.SessionManager;
+import org.apache.coyote.http11.request.HttpRequest;
+import org.apache.coyote.http11.response.HttpResponse;
+
+import static org.apache.catalina.session.Session.JSESSIONID_COOKIE_NAME;
+
+public class RegisterController extends AbstrcatController {
+
+    private static final String MAPPED_URL = "/register";
+
+    private static final String LOGIN_USER_REDIRECT_PAGE = "index.html";
+    private static final String REGISTER_PAGE = "/register.html";
+    private static final String ACCOUNT_KEY = "account";
+    private static final String PASSWORD_KEY = "password";
+    private static final String EMAIL_KEY = "email";
+
+    @Override
+    protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
+        final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
+
+        if (session != null && session.getUser() instanceof User) {
+            response.redirectTo(LOGIN_USER_REDIRECT_PAGE);
+        }
+        response.hostingPage(REGISTER_PAGE);
+    }
+
+    @Override
+    protected void doPost(HttpRequest request, HttpResponse response) throws Exception {
+        final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
+
+        final User registeredUser = processRegister(request);
+        session.setUser(registeredUser);
+        response.redirectTo(LOGIN_USER_REDIRECT_PAGE);
+    }
+
+    private User processRegister(final HttpRequest request) {
+        if (!request.containsBody(ACCOUNT_KEY) || !request.containsBody(PASSWORD_KEY) || !request.containsBody(EMAIL_KEY)) {
+            return null;
+        }
+        final String account = request.getBody(ACCOUNT_KEY);
+        final String password = request.getBody(PASSWORD_KEY);
+        final String email = request.getBody(EMAIL_KEY);
+
+        if (InMemoryUserRepository.findByAccount(account).isPresent()) {
+            return null;
+        }
+        final User registeredUser = new User(account, password, email);
+        InMemoryUserRepository.save(registeredUser);
+        return registeredUser;
+    }
+
+    @Override
+    public boolean isMappedController(HttpRequest request) {
+        return MAPPED_URL.equals(request.getPath());
+    }
+}

--- a/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
@@ -1,10 +1,12 @@
 package nextstep.jwp.controller;
 
 import nextstep.jwp.db.InMemoryUserRepository;
+import nextstep.jwp.exception.UserAlreadyExistException;
 import nextstep.jwp.model.User;
 import org.apache.catalina.controller.AbstrcatController;
 import org.apache.catalina.session.Session;
 import org.apache.catalina.session.SessionManager;
+import org.apache.coyote.http11.exception.MissingRequestBody;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.response.HttpResponse;
 
@@ -45,14 +47,14 @@ public class RegisterController extends AbstrcatController {
 
     private User processRegister(final HttpRequest request) {
         if (!request.containsBody(ACCOUNT_KEY) || !request.containsBody(PASSWORD_KEY) || !request.containsBody(EMAIL_KEY)) {
-            return null;
+            throw new MissingRequestBody();
         }
         final String account = request.getBody(ACCOUNT_KEY);
         final String password = request.getBody(PASSWORD_KEY);
         final String email = request.getBody(EMAIL_KEY);
 
         if (InMemoryUserRepository.findByAccount(account).isPresent()) {
-            return null;
+            throw new UserAlreadyExistException(account);
         }
         final User registeredUser = new User(account, password, email);
         InMemoryUserRepository.save(registeredUser);

--- a/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
@@ -28,7 +28,7 @@ public class RegisterController extends AbstrcatController {
 
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
-        final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
+        final Session session = getSession(request, response);
 
         if (session != null && session.getUser() instanceof User) {
             response.redirectTo(LOGIN_USER_REDIRECT_PAGE);

--- a/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
+++ b/tomcat/src/main/java/nextstep/jwp/controller/RegisterController.java
@@ -20,6 +20,10 @@ public class RegisterController extends AbstrcatController {
     private static final String PASSWORD_KEY = "password";
     private static final String EMAIL_KEY = "email";
 
+    public RegisterController() {
+        super(MAPPED_URL);
+    }
+
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
         final Session session = SessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
@@ -53,10 +57,5 @@ public class RegisterController extends AbstrcatController {
         final User registeredUser = new User(account, password, email);
         InMemoryUserRepository.save(registeredUser);
         return registeredUser;
-    }
-
-    @Override
-    public boolean isMappedController(HttpRequest request) {
-        return MAPPED_URL.equals(request.getPath());
     }
 }

--- a/tomcat/src/main/java/nextstep/jwp/exception/UserAlreadyExistException.java
+++ b/tomcat/src/main/java/nextstep/jwp/exception/UserAlreadyExistException.java
@@ -1,6 +1,8 @@
 package nextstep.jwp.exception;
 
-public class UserAlreadyExistException extends RuntimeException{
+import org.apache.catalina.exception.CustomBadRequestException;
+
+public class UserAlreadyExistException extends CustomBadRequestException {
 
     public UserAlreadyExistException(final String account) {
         super("이미 등록된 사용자며입니다. 입력된 사용자 명 : " + account);

--- a/tomcat/src/main/java/nextstep/jwp/exception/UserAlreadyExistException.java
+++ b/tomcat/src/main/java/nextstep/jwp/exception/UserAlreadyExistException.java
@@ -1,0 +1,8 @@
+package nextstep.jwp.exception;
+
+public class UserAlreadyExistException extends RuntimeException{
+
+    public UserAlreadyExistException(final String account) {
+        super("이미 등록된 사용자며입니다. 입력된 사용자 명 : " + account);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class Connector implements Runnable {
 
@@ -16,17 +18,20 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 250;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executorService;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
+        this.executorService = Executors.newFixedThreadPool(maxThreads);
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -68,7 +73,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection, RequestMapperImpl.getInstance());
-        new Thread(processor).start();
+        executorService.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,5 +1,6 @@
 package org.apache.catalina.connector;
 
+import org.apache.catalina.controller.RequestMapperImpl;
 import org.apache.coyote.http11.Http11Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,7 @@ public class Connector implements Runnable {
         if (connection == null) {
             return;
         }
-        var processor = new Http11Processor(connection);
+        var processor = new Http11Processor(connection, RequestMapperImpl.getInstance());
         new Thread(processor).start();
     }
 

--- a/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
@@ -1,0 +1,27 @@
+package org.apache.catalina.controller;
+
+import org.apache.coyote.http11.request.HttpRequest;
+import org.apache.coyote.http11.response.HttpResponse;
+
+public abstract class AbstrcatController implements Controller {
+
+    private static final String GET = "GET";
+    private static final String POST = "POST";
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+        if (GET.equals(request.getMethod())) {
+            doGet(request, response);
+            return;
+        }
+        if (POST.equals(request.getMethod())) {
+            doPost(request, response);
+            return;
+        }
+        response.methodNotAllowed();
+    }
+
+    protected abstract void doGet(HttpRequest request, HttpResponse response) throws Exception;
+
+    protected abstract void doPost(HttpRequest request, HttpResponse response) throws Exception;
+}

--- a/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
@@ -8,8 +8,19 @@ public abstract class AbstrcatController implements Controller {
     private static final String GET = "GET";
     private static final String POST = "POST";
 
+    private final String mappedUrl;
+
+    protected AbstrcatController(final String mappedUrl) {
+        this.mappedUrl = mappedUrl;
+    }
+
     @Override
-    public void service(HttpRequest request, HttpResponse response) throws Exception {
+    public boolean isMappedController(HttpRequest request) {
+        return mappedUrl.equals(request.getPath());
+    }
+
+    @Override
+    public final void service(HttpRequest request, HttpResponse response) throws Exception {
         if (GET.equals(request.getMethod())) {
             doGet(request, response);
             return;

--- a/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
@@ -1,5 +1,6 @@
 package org.apache.catalina.controller;
 
+import org.apache.coyote.http11.Controller;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.response.HttpResponse;
 

--- a/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/AbstrcatController.java
@@ -1,11 +1,16 @@
 package org.apache.catalina.controller;
 
+import org.apache.catalina.exception.CustomBadRequestException;
 import org.apache.coyote.http11.Controller;
+import org.apache.coyote.http11.exception.MissingRequestBody;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.response.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstrcatController implements Controller {
 
+    private static final Logger log = LoggerFactory.getLogger(AbstrcatController.class);
     private static final String GET = "GET";
     private static final String POST = "POST";
 
@@ -22,15 +27,20 @@ public abstract class AbstrcatController implements Controller {
 
     @Override
     public final void service(HttpRequest request, HttpResponse response) throws Exception {
-        if (GET.equals(request.getMethod())) {
-            doGet(request, response);
-            return;
+        try {
+            if (GET.equals(request.getMethod())) {
+                doGet(request, response);
+                return;
+            }
+            if (POST.equals(request.getMethod())) {
+                doPost(request, response);
+                return;
+            }
+            response.methodNotAllowed();
+        } catch (MissingRequestBody | CustomBadRequestException e) {
+            log.warn(e.getMessage());
+            response.badRequest(e.getMessage());
         }
-        if (POST.equals(request.getMethod())) {
-            doPost(request, response);
-            return;
-        }
-        response.methodNotAllowed();
     }
 
     protected abstract void doGet(HttpRequest request, HttpResponse response) throws Exception;

--- a/tomcat/src/main/java/org/apache/catalina/controller/Controller.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/Controller.java
@@ -1,0 +1,10 @@
+package org.apache.catalina.controller;
+
+import org.apache.coyote.http11.request.HttpRequest;
+import org.apache.coyote.http11.response.HttpResponse;
+
+public interface Controller {
+
+    boolean isMappedController(HttpRequest request);
+    void service(HttpRequest request, HttpResponse response) throws Exception;
+}

--- a/tomcat/src/main/java/org/apache/catalina/controller/DefaultController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/DefaultController.java
@@ -1,0 +1,31 @@
+package org.apache.catalina.controller;
+
+import org.apache.coyote.http11.request.HttpRequest;
+import org.apache.coyote.http11.response.HttpResponse;
+
+public class DefaultController extends AbstrcatController {
+
+    private static final DefaultController instance = new DefaultController();
+
+    public static DefaultController getInstance() {
+        return instance;
+    }
+
+    private DefaultController() {
+    }
+
+    @Override
+    public boolean isMappedController(HttpRequest request) {
+        return false;
+    }
+
+    @Override
+    protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
+        response.hostingPage(request.getPath());
+    }
+
+    @Override
+    protected void doPost(HttpRequest request, HttpResponse response) throws Exception {
+        response.methodNotAllowed();
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/controller/DefaultController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/DefaultController.java
@@ -1,11 +1,16 @@
 package org.apache.catalina.controller;
 
+import org.apache.coyote.http11.exception.HostingFileNotFoundException;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.response.HttpResponse;
+import org.apache.coyote.http11.response.HttpStatus;
+
+import java.io.IOException;
 
 public class DefaultController extends AbstrcatController {
 
     private static final DefaultController instance = new DefaultController();
+    private static final String NOT_FOUND_PAGE = "/404.html";
 
     private DefaultController() {
         super("");
@@ -22,7 +27,12 @@ public class DefaultController extends AbstrcatController {
 
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
-        response.hostingPage(request.getPath());
+        try {
+            response.hostingPage(request.getPath());
+        } catch (HostingFileNotFoundException e) {
+            response.hostingPage(NOT_FOUND_PAGE);
+            response.setStatus(HttpStatus.NOT_FOUND);
+        }
     }
 
     @Override

--- a/tomcat/src/main/java/org/apache/catalina/controller/DefaultController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/DefaultController.java
@@ -7,11 +7,12 @@ public class DefaultController extends AbstrcatController {
 
     private static final DefaultController instance = new DefaultController();
 
-    public static DefaultController getInstance() {
-        return instance;
+    private DefaultController() {
+        super("");
     }
 
-    private DefaultController() {
+    public static DefaultController getInstance() {
+        return instance;
     }
 
     @Override

--- a/tomcat/src/main/java/org/apache/catalina/controller/RequestMapperImpl.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/RequestMapperImpl.java
@@ -1,0 +1,37 @@
+package org.apache.catalina.controller;
+
+import nextstep.jwp.controller.LoginController;
+import nextstep.jwp.controller.RegisterController;
+import org.apache.coyote.http11.Controller;
+import org.apache.coyote.http11.RequestMapper;
+import org.apache.coyote.http11.request.HttpRequest;
+
+import java.util.List;
+
+public class RequestMapperImpl implements RequestMapper {
+
+    private static final RequestMapper instance = new RequestMapperImpl();
+
+    private static final List<Controller> CONTROLLERS;
+
+    static {
+        CONTROLLERS = List.of(
+                new LoginController(),
+                new RegisterController()
+        );
+    }
+
+    private RequestMapperImpl() {
+    }
+
+    public static RequestMapper getInstance() {
+        return instance;
+    }
+
+    public Controller getController(final HttpRequest request) {
+        return CONTROLLERS.stream()
+                .filter(controller -> controller.isMappedController(request))
+                .findAny()
+                .orElse(DefaultController.getInstance());
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/exception/CustomBadRequestException.java
+++ b/tomcat/src/main/java/org/apache/catalina/exception/CustomBadRequestException.java
@@ -1,0 +1,11 @@
+package org.apache.catalina.exception;
+
+public class CustomBadRequestException extends RuntimeException {
+
+    public CustomBadRequestException() {
+    }
+
+    public CustomBadRequestException(final String message) {
+        super(message);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/session/Session.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/Session.java
@@ -5,6 +5,10 @@ import java.util.Map;
 
 public class Session {
 
+    public static final String JSESSIONID_COOKIE_NAME = "JSESSIONID";
+
+    private static final String USER_ATTRIBUTE_NAME = "user";
+
     private final String id;
     private final Map<String, Object> values;
 
@@ -21,8 +25,16 @@ public class Session {
         values.put(name, value);
     }
 
+    public void setUser(final Object user) {
+        values.put(USER_ATTRIBUTE_NAME, user);
+    }
+
     public Object getAttribute(final String name) {
         return values.get(name);
+    }
+
+    public Object getUser() {
+        return values.get(USER_ATTRIBUTE_NAME);
     }
 
     public void removeAttribute(final String name) {

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -7,15 +7,15 @@ public class SessionManager {
 
     private static final Map<String, Session> SESSIONS = new HashMap<>();
 
-     public void addSession(final Session session) {
+     public static void addSession(final Session session) {
          SESSIONS.put(session.getId(), session);
      }
 
-     public Session findSession(final String sessionId) {
+     public static Session findSession(final String sessionId) {
          return SESSIONS.get(sessionId);
      }
 
-     public void removeSession(final String sessionId) {
+     public static void removeSession(final String sessionId) {
          SESSIONS.remove(sessionId);
      }
 }

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -1,21 +1,21 @@
 package org.apache.catalina.session;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SessionManager {
 
-    private static final Map<String, Session> SESSIONS = new HashMap<>();
+    private static final Map<String, Session> SESSIONS = new ConcurrentHashMap<>();
 
-     public static void addSession(final Session session) {
-         SESSIONS.put(session.getId(), session);
-     }
+    public static void addSession(final Session session) {
+        SESSIONS.put(session.getId(), session);
+    }
 
-     public static Session findSession(final String sessionId) {
-         return SESSIONS.get(sessionId);
-     }
+    public static Session findSession(final String sessionId) {
+        return SESSIONS.get(sessionId);
+    }
 
-     public static void removeSession(final String sessionId) {
-         SESSIONS.remove(sessionId);
-     }
+    public static void removeSession(final String sessionId) {
+        SESSIONS.remove(sessionId);
+    }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Controller.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Controller.java
@@ -1,4 +1,4 @@
-package org.apache.catalina.controller;
+package org.apache.coyote.http11;
 
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.response.HttpResponse;
@@ -6,5 +6,6 @@ import org.apache.coyote.http11.response.HttpResponse;
 public interface Controller {
 
     boolean isMappedController(HttpRequest request);
+
     void service(HttpRequest request, HttpResponse response) throws Exception;
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,8 +1,7 @@
 package org.apache.coyote.http11;
 
-import nextstep.jwp.db.InMemoryUserRepository;
 import nextstep.jwp.exception.UncheckedServletException;
-import nextstep.jwp.model.User;
+import org.apache.catalina.controller.Controller;
 import org.apache.catalina.session.Session;
 import org.apache.catalina.session.SessionManager;
 import org.apache.coyote.Processor;
@@ -19,19 +18,12 @@ import java.net.Socket;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
+import static org.apache.catalina.session.Session.JSESSIONID_COOKIE_NAME;
+
 public class Http11Processor implements Runnable, Processor {
 
     private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
-    private static final String ACCOUNT_KEY = "account";
-    private static final String PASSWORD_KEY = "password";
-    private static final String EMAIL_KEY = "email";
-    private static final String INDEX_PAGE = "/index.html";
-    private static final String LOGIN_PAGE = "/login.html";
-    private static final String UNAUTHORIZED_PAGE = "/401.html";
-    private static final String REGISTER_PAGE = "/register.html";
-    private static final String JSESSIONID_COOKIE_NAME = "JSESSIONID";
-    private static final String USER_SESSION_ATTRIBUTE_NAME = "user";
-    private static final SessionManager sessionManager = new SessionManager();
+    private static final RequestMapper requestMapper = new RequestMapper();
 
     private final Socket connection;
 
@@ -50,113 +42,32 @@ public class Http11Processor implements Runnable, Processor {
         try (final var outputStream = connection.getOutputStream();
              final var inputStream = connection.getInputStream();
              final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))
-             ) {
+        ) {
             final HttpRequest request = HttpRequestFactory.readFrom(bufferedReader);
+            final HttpResponse response = new HttpResponse();
 
-            final HttpResponse response = handleRequest(request);
+            makeSessionIfNotExist(request, response);
+
+            final Controller controller = requestMapper.getController(request);
+            controller.service(request, response);
 
             outputStream.write(response.getBytes());
             outputStream.flush();
+
         } catch (IOException | UncheckedServletException | URISyntaxException e) {
+            log.error(e.getMessage(), e);
+        } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
     }
 
-    public HttpResponse handleRequest(final HttpRequest request) throws URISyntaxException {
-
-        final HttpResponse response = new HttpResponse();
-
-        makeSessionIfNotExist(request, response);
-
-        final String uriPath = request.getPath();
-
-        if (uriPath.equals("/login")) {
-            return handleLogin(request, response);
-        }
-
-        if (uriPath.equals("/register")) {
-            return handleRegister(request, response);
-        }
-
-        response.hostingPage(uriPath);
-        return response;
-    }
-
     private void makeSessionIfNotExist(final HttpRequest request, final HttpResponse response) {
         final String sessionId = request.getCookie(JSESSIONID_COOKIE_NAME);
-        if (sessionManager.findSession(sessionId) == null) {
+        if (SessionManager.findSession(sessionId) == null) {
             final UUID generatedSessionId = UUID.randomUUID();
             final Session session = new Session(generatedSessionId.toString());
-            sessionManager.addSession(session);
+            SessionManager.addSession(session);
             response.setCookie(JSESSIONID_COOKIE_NAME, session.getId());
         }
-    }
-
-    private HttpResponse handleLogin(final HttpRequest request, final HttpResponse response) {
-
-        final Session session = sessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
-
-        if (request.getMethod().equals("GET")) {
-            if (session != null && session.getAttribute(USER_SESSION_ATTRIBUTE_NAME) instanceof User) {
-                return response.redirectTo(INDEX_PAGE);
-            }
-            return response.hostingPage(LOGIN_PAGE);
-        }
-
-        if (request.getMethod().equals("POST")) {
-            if (processLogin(request)) {
-                final User user = InMemoryUserRepository.findByAccount(request.getBody(ACCOUNT_KEY)).get();
-                session.setAttribute(USER_SESSION_ATTRIBUTE_NAME, user);
-                return response.redirectTo(INDEX_PAGE);
-            }
-            return response.redirectTo(UNAUTHORIZED_PAGE);
-        }
-        return response.methodNotAllowed();
-    }
-
-    public boolean processLogin(final HttpRequest request) {
-        if (!request.containsBody(ACCOUNT_KEY) || !request.containsBody(PASSWORD_KEY)) {
-            return false;
-        }
-        final String account = request.getBody(ACCOUNT_KEY);
-        final String password = request.getBody(PASSWORD_KEY);
-
-        return InMemoryUserRepository.findByAccount(account)
-                .map(user -> user.checkPassword(password))
-                .orElse(false);
-    }
-
-    private HttpResponse handleRegister(final HttpRequest request, final HttpResponse response) {
-
-        final Session session = sessionManager.findSession(request.getCookie(JSESSIONID_COOKIE_NAME));
-
-        if (request.getMethod().equals("GET")) {
-            if (session != null && session.getAttribute(USER_SESSION_ATTRIBUTE_NAME) instanceof User) {
-                return response.redirectTo(INDEX_PAGE);
-            }
-            return response.hostingPage(REGISTER_PAGE);
-        }
-        if (request.getMethod().equals("POST")) {
-            final User registeredUser = processRegister(request);
-            session.setAttribute(USER_SESSION_ATTRIBUTE_NAME, registeredUser);
-            return response.redirectTo(INDEX_PAGE);
-        }
-        return response.methodNotAllowed();
-    }
-
-    public User processRegister(final HttpRequest request) {
-        if (!request.containsBody(ACCOUNT_KEY) || !request.containsBody(PASSWORD_KEY) || !request.containsBody(EMAIL_KEY)) {
-            return null;
-        }
-        final String account = request.getBody(ACCOUNT_KEY);
-        final String password = request.getBody(PASSWORD_KEY);
-        final String email = request.getBody(EMAIL_KEY);
-
-        if (InMemoryUserRepository.findByAccount(account).isPresent()) {
-            return null;
-        }
-        final User registeredUser = new User(account, password, email);
-        InMemoryUserRepository.save(registeredUser);
-        return registeredUser;
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -2,7 +2,6 @@ package org.apache.coyote.http11;
 
 import nextstep.jwp.exception.UncheckedServletException;
 import nextstep.jwp.exception.UserAlreadyExistException;
-import org.apache.catalina.controller.Controller;
 import org.apache.catalina.session.Session;
 import org.apache.catalina.session.SessionManager;
 import org.apache.coyote.Processor;
@@ -25,12 +24,13 @@ import static org.apache.catalina.session.Session.JSESSIONID_COOKIE_NAME;
 public class Http11Processor implements Runnable, Processor {
 
     private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
-    private static final RequestMapper requestMapper = new RequestMapper();
 
+    private final RequestMapper requestMapper;
     private final Socket connection;
 
-    public Http11Processor(final Socket connection) {
+    public Http11Processor(final Socket connection, final RequestMapper requestMapper) {
         this.connection = connection;
+        this.requestMapper = requestMapper;
     }
 
     @Override

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,11 +1,9 @@
 package org.apache.coyote.http11;
 
 import nextstep.jwp.exception.UncheckedServletException;
-import nextstep.jwp.exception.UserAlreadyExistException;
 import org.apache.catalina.session.Session;
 import org.apache.catalina.session.SessionManager;
 import org.apache.coyote.Processor;
-import org.apache.coyote.http11.exception.MissingRequestBody;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.request.HttpRequestFactory;
 import org.apache.coyote.http11.response.HttpResponse;
@@ -53,12 +51,7 @@ public class Http11Processor implements Runnable, Processor {
             makeSessionIfNotExist(request, response);
 
             final Controller controller = requestMapper.getController(request);
-            try {
-                controller.service(request, response);
-            } catch (MissingRequestBody | UserAlreadyExistException e) {
-                log.warn(e.getMessage());
-                response.badRequest(e.getMessage());
-            }
+            controller.service(request, response);
 
             outputStream.write(response.getBytes());
             outputStream.flush();

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,8 +1,6 @@
 package org.apache.coyote.http11;
 
 import nextstep.jwp.exception.UncheckedServletException;
-import org.apache.catalina.session.Session;
-import org.apache.catalina.session.SessionManager;
 import org.apache.coyote.Processor;
 import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.request.HttpRequestFactory;
@@ -15,9 +13,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
 import java.net.URISyntaxException;
-import java.util.UUID;
-
-import static org.apache.catalina.session.Session.JSESSIONID_COOKIE_NAME;
 
 public class Http11Processor implements Runnable, Processor {
 
@@ -48,8 +43,6 @@ public class Http11Processor implements Runnable, Processor {
         ) {
             final HttpRequest request = HttpRequestFactory.readFrom(bufferedReader);
 
-            makeSessionIfNotExist(request, response);
-
             final Controller controller = requestMapper.getController(request);
             controller.service(request, response);
 
@@ -60,16 +53,6 @@ public class Http11Processor implements Runnable, Processor {
             log.error(e.getMessage(), e);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
-        }
-    }
-
-    private void makeSessionIfNotExist(final HttpRequest request, final HttpResponse response) {
-        final String sessionId = request.getCookie(JSESSIONID_COOKIE_NAME);
-        if (SessionManager.findSession(sessionId) == null) {
-            final UUID generatedSessionId = UUID.randomUUID();
-            final Session session = new Session(generatedSessionId.toString());
-            SessionManager.addSession(session);
-            response.setCookie(JSESSIONID_COOKIE_NAME, session.getId());
         }
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/RequestMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/RequestMapper.java
@@ -1,0 +1,28 @@
+package org.apache.coyote.http11;
+
+import nextstep.jwp.controller.LoginController;
+import nextstep.jwp.controller.RegisterController;
+import org.apache.catalina.controller.Controller;
+import org.apache.catalina.controller.DefaultController;
+import org.apache.coyote.http11.request.HttpRequest;
+
+import java.util.List;
+
+public class RequestMapper {
+
+    private static final List<Controller> CONTROLLERS;
+
+    static {
+        CONTROLLERS = List.of(
+                new LoginController(),
+                new RegisterController()
+        );
+    }
+
+    public Controller getController(final HttpRequest request) {
+        return CONTROLLERS.stream()
+                .filter(controller -> controller.isMappedController(request))
+                .findAny()
+                .orElse(DefaultController.getInstance());
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/RequestMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/RequestMapper.java
@@ -1,28 +1,8 @@
 package org.apache.coyote.http11;
 
-import nextstep.jwp.controller.LoginController;
-import nextstep.jwp.controller.RegisterController;
-import org.apache.catalina.controller.Controller;
-import org.apache.catalina.controller.DefaultController;
 import org.apache.coyote.http11.request.HttpRequest;
 
-import java.util.List;
+public interface RequestMapper {
 
-public class RequestMapper {
-
-    private static final List<Controller> CONTROLLERS;
-
-    static {
-        CONTROLLERS = List.of(
-                new LoginController(),
-                new RegisterController()
-        );
-    }
-
-    public Controller getController(final HttpRequest request) {
-        return CONTROLLERS.stream()
-                .filter(controller -> controller.isMappedController(request))
-                .findAny()
-                .orElse(DefaultController.getInstance());
-    }
+    Controller getController(HttpRequest request);
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/exception/HostingFileNotFoundException.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/exception/HostingFileNotFoundException.java
@@ -1,0 +1,4 @@
+package org.apache.coyote.http11.exception;
+
+public class HostingFileNotFoundException extends RuntimeException {
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/exception/MissingRequestBody.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/exception/MissingRequestBody.java
@@ -1,0 +1,8 @@
+package org.apache.coyote.http11.exception;
+
+public class MissingRequestBody extends RuntimeException {
+
+    public MissingRequestBody() {
+        super("누락된 request body가 있습니다.");
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/request/RequestCookie.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/request/RequestCookie.java
@@ -7,7 +7,7 @@ public class RequestCookie {
 
     public static final String COOKIE_HEADER_KEY = "Cookie";
     public static final String COOKIE_DELIMITER = "; ";
-    public static final String KEY_VALUE_DELIMITER = "=";
+    private static final String KEY_VALUE_DELIMITER = "=";
     private static final int KEY_INDEX = 0;
     private static final int VALUE_INDEX = 1;
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpContentType.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpContentType.java
@@ -1,0 +1,43 @@
+package org.apache.coyote.http11.response;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public enum HttpContentType {
+    HTML("text/html;charset=utf-8", "html"),
+    CSS("text/css;charset=utf-8", "css"),
+    JAVASCRIPT("text/javascript", "js"),
+    PLAIN_TEXT("text/plain;charset=utf-8", "txt");
+
+    private static final Map<String, HttpContentType> CONTENT_TYPE_BY_EXTENSION;
+
+    static {
+        CONTENT_TYPE_BY_EXTENSION = Stream.of(HttpContentType.values())
+                .collect(Collectors.toMap(
+                        httpContentType -> httpContentType.fileExtension,
+                        httpContentType -> httpContentType));
+    }
+
+    public static HttpContentType getByFilePath(final String filePath) {
+        final String[] fileNameSplit = filePath.split("\\.");
+        final String fileType = fileNameSplit[fileNameSplit.length - 1];
+
+        return CONTENT_TYPE_BY_EXTENSION.getOrDefault(
+                fileType,
+                PLAIN_TEXT
+        );
+    }
+
+    private final String headerString;
+    private final String fileExtension;
+
+    HttpContentType(String headerString, String fileExtension) {
+        this.headerString = headerString;
+        this.fileExtension = fileExtension;
+    }
+
+    public String getHeaderString() {
+        return headerString;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpContentType.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpContentType.java
@@ -20,6 +20,14 @@ public enum HttpContentType {
                         httpContentType -> httpContentType));
     }
 
+    private final String headerString;
+    private final String fileExtension;
+
+    HttpContentType(String headerString, String fileExtension) {
+        this.headerString = headerString;
+        this.fileExtension = fileExtension;
+    }
+
     public static HttpContentType getByFilePath(final String filePath) {
         final String[] fileNameSplit = filePath.split("\\.");
         final String fileType = fileNameSplit[fileNameSplit.length - 1];
@@ -28,14 +36,6 @@ public enum HttpContentType {
                 fileType,
                 PLAIN_TEXT
         );
-    }
-
-    private final String headerString;
-    private final String fileExtension;
-
-    HttpContentType(String headerString, String fileExtension) {
-        this.headerString = headerString;
-        this.fileExtension = fileExtension;
     }
 
     public String getHeaderString() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpContentType.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpContentType.java
@@ -8,7 +8,8 @@ public enum HttpContentType {
     HTML("text/html;charset=utf-8", "html"),
     CSS("text/css;charset=utf-8", "css"),
     JAVASCRIPT("text/javascript", "js"),
-    PLAIN_TEXT("text/plain;charset=utf-8", "txt");
+    PLAIN_TEXT("text/plain;charset=utf-8", "txt"),
+    SVG("image/svg+xml", "svg");
 
     private static final Map<String, HttpContentType> CONTENT_TYPE_BY_EXTENSION;
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -47,23 +47,8 @@ public class HttpResponse {
     }
 
     private String getContentType(final String filePath) {
-        final String[] fileNameSplit = filePath.split("\\.");
-        final String fileType = fileNameSplit[fileNameSplit.length - 1];
-
-        if (fileType.equals("html")) {
-            return "text/html;charset=utf-8";
-        }
-        if (fileType.equals("css")) {
-            return "text/css;charset=utf-8";
-        }
-        if (fileType.equals("js")) {
-            return "application/javascript";
-        }
-
-        if (filePath.equals("/")) {
-            return "text/html;charset=utf-8";
-        }
-        return null;
+        final HttpContentType contentType = HttpContentType.getByFilePath(filePath);
+        return contentType.getHeaderString();
     }
 
     public HttpResponse redirectTo(final String redirectUrl) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -25,14 +25,13 @@ public class HttpResponse {
         headers.addHeader(headerName, value);
     }
 
-    public HttpResponse hostingPage(final String filePath) {
+    public void hostingPage(final String filePath) {
         responseBody = readStaticFile(filePath);
 
         headers.setContentType(getContentType(filePath));
         headers.setContentLength(responseBody.getBytes().length);
 
         status = HttpStatus.OK;
-        return this;
     }
 
     private String readStaticFile(final String fileName) {
@@ -51,17 +50,21 @@ public class HttpResponse {
         return contentType.getHeaderString();
     }
 
-    public HttpResponse redirectTo(final String redirectUrl) {
+    public void redirectTo(final String redirectUrl) {
         headers.setLocation(redirectUrl);
         status = HttpStatus.FOUND;
         responseBody = null;
-        return this;
     }
 
-    public HttpResponse methodNotAllowed() {
+    public void methodNotAllowed() {
         status = HttpStatus.METHOD_NOT_ALLOWED;
         responseBody = null;
-        return this;
+    }
+
+    public void badRequest(final String message) {
+        status = HttpStatus.BAD_REQUEST;
+        headers.setContentType(HttpContentType.PLAIN_TEXT.getHeaderString());
+        responseBody = message;
     }
 
     public void setCookie(final String cookieName, final String value) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -1,5 +1,7 @@
 package org.apache.coyote.http11.response;
 
+import org.apache.coyote.http11.exception.HostingFileNotFoundException;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -25,7 +27,7 @@ public class HttpResponse {
         headers.addHeader(headerName, value);
     }
 
-    public void hostingPage(final String filePath) {
+    public void hostingPage(final String filePath) throws IOException {
         responseBody = readStaticFile(filePath);
 
         headers.setContentType(getContentType(filePath));
@@ -34,14 +36,17 @@ public class HttpResponse {
         status = HttpStatus.OK;
     }
 
-    private String readStaticFile(final String fileName) {
+    private String readStaticFile(final String fileName) throws IOException {
         final String filePath = "static/" + fileName;
         final URL res = CLASS_LOADER.getResource(filePath);
 
+        if (fileName.equals("/")) {
+            return "Hello world!";
+        }
         try {
             return new String(Files.readAllBytes(new File(res.getFile()).toPath()));
-        } catch (IOException e) {
-            return "Hello world!";
+        } catch (NullPointerException e) {
+            throw new HostingFileNotFoundException();
         }
     }
 
@@ -81,5 +86,9 @@ public class HttpResponse {
 
     public byte[] getBytes() {
         return getResponseString().getBytes();
+    }
+
+    public void setStatus(final HttpStatus httpStatus) {
+        this.status = httpStatus;
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpStatus.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpStatus.java
@@ -3,8 +3,9 @@ package org.apache.coyote.http11.response;
 public enum HttpStatus {
     OK("200 OK"),
     FOUND("302 Found"),
-    METHOD_NOT_ALLOWED("405 Method Not Allowed"),
-    BAD_REQUEST("400 Bad Request");
+    BAD_REQUEST("400 Bad Request"),
+    NOT_FOUND("404 Not Found"),
+    METHOD_NOT_ALLOWED("405 Method Not Allowed");
 
     private final String code;
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpStatus.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpStatus.java
@@ -3,7 +3,8 @@ package org.apache.coyote.http11.response;
 public enum HttpStatus {
     OK("200 OK"),
     FOUND("302 Found"),
-    METHOD_NOT_ALLOWED("405 Method Not Allowed");
+    METHOD_NOT_ALLOWED("405 Method Not Allowed"),
+    BAD_REQUEST("400 Bad Request");
 
     private final String code;
 

--- a/tomcat/src/test/java/nextstep/org/apache/coyote/http11/Http11ProcessorTest.java
+++ b/tomcat/src/test/java/nextstep/org/apache/coyote/http11/Http11ProcessorTest.java
@@ -1,8 +1,8 @@
 package nextstep.org.apache.coyote.http11;
 
-import support.StubSocket;
 import org.apache.coyote.http11.Http11Processor;
 import org.junit.jupiter.api.Test;
+import support.StubSocket;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,20 +27,20 @@ class Http11ProcessorTest {
         final String actual = socket.output();
         final List<String> expected = List.of("\r\n",
                 "HTTP/1.1 200 OK ",
-                "Content-Type: text/html;charset=utf-8 ",
+                "Content-Type: text/plain;charset=utf-8 ",
                 "Content-Length: 12 ",
                 "",
                 "Hello world!");
 
         final boolean allMatch = expected.stream()
-                        .allMatch(actual::contains);
+                .allMatch(actual::contains);
         assertThat(allMatch).isTrue();
     }
 
     @Test
     void index() throws IOException {
         // given
-        final String httpRequest= String.join("\r\n",
+        final String httpRequest = String.join("\r\n",
                 "GET /index.html HTTP/1.1 ",
                 "Host: localhost:8080 ",
                 "Connection: keep-alive ",
@@ -63,7 +63,7 @@ class Http11ProcessorTest {
                 new String(Files.readAllBytes(new File(resource.getFile()).toPath())));
 
         boolean allMatches = expected.stream()
-                        .allMatch(actual::contains);
+                .allMatch(actual::contains);
         assertThat(allMatches).isTrue();
     }
 }

--- a/tomcat/src/test/java/nextstep/org/apache/coyote/http11/Http11ProcessorTest.java
+++ b/tomcat/src/test/java/nextstep/org/apache/coyote/http11/Http11ProcessorTest.java
@@ -1,5 +1,6 @@
 package nextstep.org.apache.coyote.http11;
 
+import org.apache.catalina.controller.RequestMapperImpl;
 import org.apache.coyote.http11.Http11Processor;
 import org.junit.jupiter.api.Test;
 import support.StubSocket;
@@ -18,7 +19,7 @@ class Http11ProcessorTest {
     void process() {
         // given
         final var socket = new StubSocket();
-        final var processor = new Http11Processor(socket);
+        final var processor = new Http11Processor(socket, RequestMapperImpl.getInstance());
 
         // when
         processor.process(socket);
@@ -48,7 +49,7 @@ class Http11ProcessorTest {
                 "");
 
         final var socket = new StubSocket(httpRequest);
-        final Http11Processor processor = new Http11Processor(socket);
+        final Http11Processor processor = new Http11Processor(socket, RequestMapperImpl.getInstance());
 
         // when
         processor.process(socket);


### PR DESCRIPTION
안녕하세요 허브!!

3-4단계 미션 제출합니다 라고 하고,, 일단은 3단계만 진행이 되어서 우선 제출합니다..ㅠㅜ
코멘트 주시면 반영하면서 4단계도 같이 해 놓겠습니다ㅠ

지난 미션에서 `instanceof`로 검증한 이유 [질문](https://github.com/woowacourse/jwp-dashboard-http/pull/393#discussion_r1318602495) 대한 대답은 아래와 같습니다.

로그인한 회원 정보가 있는지 확인하는데, 세션에 해당 "user"라는 attribute가 있는지만으로 될까..? 해당 attribute가 User임을 확인을 해야하지 않을까..? 라는 생각으로 하게 되었습니다..
Session의 map에서 value를 Object로 관리하기 때문에 적절한 객체가 들어가있는지 판단이 필요하다는 생각이였습니다. 그렇다고 Session내부에서 User클래로 캐스팅을 하는등의 처리를 하기에는 apache 패키지에서 도메인 클래스에 의존성이 생기기에, 안하는것이 좋을 것 같다고 생각을 하였기 때문입니다..!

---

이번 미션을 진행하며 `Controller`, `AbstrcatController`는 `catalina`패키지에 두었고, 해당 `AbstractController`를 상속받는 `LoginController`, `RegisterController`들은 jwp 패키지에 두었습니다.

마음같아서는 RequestMapper에서도 jwp패키지로의 의존성을 끊어야 겠다고 생각을 했는데 아직 어떻게 하면 좋겠다라는 마땅한 생각이 안나서 처리하지는 못하였습니다..ㅠㅜ
좋은 방법이 떠오른다면 적용해보도록 하겠습니다.

허브신님의 매운 리뷰들 기대하겠습니다..! 